### PR TITLE
Add OLED display, use u8x8 lib

### DIFF
--- a/asaklitt.ino
+++ b/asaklitt.ino
@@ -96,6 +96,8 @@ void taskOneFunc(){
     static unsigned long lcdTaskTimerStop = 0;
     static unsigned int  lcdTaskTimerVal = 0;
 
+    int symbolPositionOffset = 0;                            /* For OLED display setCursor() */
+
     fullTaskTimerVal = fullTaskTimerStop - fullTaskTimerStart;
     logTaskTimerVal = logTaskTimerStop - logTaskTimerStart;
     lcdTaskTimerVal = lcdTaskTimerStop - lcdTaskTimerStart;
@@ -274,6 +276,28 @@ void taskOneFunc(){
     }
   }
   logTaskTimerStop = millis();
+
+  /* Display time and date */
+  // TODO: Add correct switching from 59 to 00, and MSB for values = 0-9 
+  //oled.drawString(0, 0, "              ");
+  symbolPositionOffset = hour < 10 ? 1 : 0;
+  oled.setCursor(0 + symbolPositionOffset, 0);
+  oled.print(hour);
+  oled.print(":");
+  symbolPositionOffset = minu < 10 ? 1 : 0;
+  oled.setCursor(3 + symbolPositionOffset, 0);
+  oled.print(minu);
+  oled.print(":");
+  symbolPositionOffset = seco < 10 ? 1 : 0;
+  oled.setCursor(6 + symbolPositionOffset, 0);
+  oled.print(seco);
+  symbolPositionOffset = day < 10 ? 1 : 0;
+  oled.setCursor(9 + symbolPositionOffset, 0);
+  oled.print(day);
+  oled.print("-");
+  symbolPositionOffset = mnth < 10 ? 1 : 0;
+  oled.setCursor(12 + symbolPositionOffset, 0);
+  oled.print(mnth);
 
   // Serial.print(logString);
   // Serial.print(logStringFile);

--- a/asaklitt.ino
+++ b/asaklitt.ino
@@ -263,6 +263,7 @@ void taskOneFunc(){
   //   + "\n";
   
   logTaskTimerStart = millis();
+
   if (GV_LogFileErrorIndicator != true)
   {
     logAsklitt = SD.open(GV_LogFileName, FILE_WRITE);
@@ -277,13 +278,14 @@ void taskOneFunc(){
           );
       // logAsklitt.print(logStringFile);
       logAsklitt.print(sdLogBuffer);
+      logAsklitt.close();
     }
     else
     {
       /* Error indicator */
       oled.drawString(15, 3, "*");
     }
-    logAsklitt.close();
+    //logAsklitt.close();
   }
   logTaskTimerStop = millis();
 
@@ -312,7 +314,7 @@ void taskOneFunc(){
   // Serial.print(logString);
   // Serial.print(logStringFile);
   
-  Serial.print(sdLogBuffer);
+  //Serial.print(sdLogBuffer);
 
   previousSensorValue = sensorValue;
   previousDynamicThr = dynamicIlluminanceThr;
@@ -329,9 +331,14 @@ void sdCardProgram()
 
   oled.drawString(0, 0, "SD Card Init...");
 
-  if (!card.init(SPI_HALF_SPEED, 4))
+  if (!card.init(SPI_HALF_SPEED, SD_CHIP_SELECT_PIN))  // SPI_HALF_SPEED, 4    SPI_FULL_SPEED SD_CHIP_SELECT_PIN
   {
     oled.drawString(0, 1, "SD Init Failed.");
+    char sdErrCode = card.errorCode();
+    char sdErrData = card.errorData();
+    oled.drawString(0, 2, sdErrCode);
+    oled.drawString(0, 3, sdErrData);
+    delay(1000);
   }
   else
   {
@@ -351,7 +358,7 @@ void sdCardProgram()
       cardType = "SDHC";
       break;
     default:
-      cardType = "??";
+      cardType = "--";
   }
   oled.drawString(0, 2, "Card Type: ");
   oled.setCursor(11, 2);
@@ -400,8 +407,9 @@ void setup()
   //   + (mm < 10 ? "0" : "") + mm 
   // //  + (sc < 10 ? "0" : "") + sc
   //   + ".txt";
-  sprintf(GV_LogFileName, "as%02d%02d%02d.txt", dd, hh, mm);
-  logAsklitt = SD.open(GV_LogFileName, FILE_WRITE);
+  //sprintf(GV_LogFileName, "as%02d%02d%02d.txt", dd, hh, mm);
+  //logAsklitt = SD.open(GV_LogFileName, FILE_WRITE);
+  logAsklitt = SD.open("lgfile.txt", FILE_WRITE);
   if(logAsklitt)
   {
     logAsklitt.print(F("--- Starting new log entry ---\n"));

--- a/asaklitt.ino
+++ b/asaklitt.ino
@@ -33,6 +33,7 @@
 #define BEAM_OFF_DELTA    (100)   /* CdS cell illuminance delta for 'Torch Beam Off' state detection */
 #define ILLUMINANCE_DARK  (1000)  /* Value for background noise */
 #define SD_LOG_BUFFER_LEN (78)    /* String buffer length for SD log file */
+#define SD_LOG_FILE_NAME_LEN  (13)  
 // #define HIGH            (1)
 // #define LOW             (0)
 
@@ -40,7 +41,8 @@
  * Module globals
  */
 
-static String   GV_LogFileName = "asddhhmm.txt";    /* File name format: "asDDHHMM.txt" -> asaklitt, day, hours, minutes */
+//static String   GV_LogFileName = "asddhhmm.txt";    /* File name format: "asDDHHMM.txt" -> asaklitt, day, hours, minutes */
+static char     GV_LogFileName[SD_LOG_FILE_NAME_LEN] = "asddhhmm.txt";
 static bool     GV_LogFileErrorIndicator = false;
 
 //const char someString[10] PROGMEM;
@@ -275,13 +277,13 @@ void taskOneFunc(){
           );
       // logAsklitt.print(logStringFile);
       logAsklitt.print(sdLogBuffer);
-      logAsklitt.close();
     }
     else
     {
       /* Error indicator */
       oled.drawString(15, 3, "*");
     }
+    logAsklitt.close();
   }
   logTaskTimerStop = millis();
 
@@ -392,12 +394,13 @@ void setup()
   int hh = now.hour();
   int mm = now.minute();
   // int sc = now.second();
-  GV_LogFileName = String("as") + 
-    + (dd < 10 ? "0" : "") + dd
-    + (hh < 10 ? "0" : "") + hh
-    + (mm < 10 ? "0" : "") + mm 
-  //  + (sc < 10 ? "0" : "") + sc
-    + ".txt";
+  // GV_LogFileName = String("as") + 
+  //   + (dd < 10 ? "0" : "") + dd
+  //   + (hh < 10 ? "0" : "") + hh
+  //   + (mm < 10 ? "0" : "") + mm 
+  // //  + (sc < 10 ? "0" : "") + sc
+  //   + ".txt";
+  sprintf(GV_LogFileName, "as%02d%02d%02d.txt", dd, hh, mm);
   logAsklitt = SD.open(GV_LogFileName, FILE_WRITE);
   if(logAsklitt)
   {

--- a/asaklitt.ino
+++ b/asaklitt.ino
@@ -12,7 +12,6 @@
 #include <Thread.h>
 #include <SPI.h>
 #include <SD.h>
-
 #include <Wire.h>
 
 // #include "Adafruit_Sensor.h"
@@ -33,6 +32,7 @@
 #define ILLUMINANCE_THR   (500)   /* Absolute threshold for CdS cell */
 #define BEAM_OFF_DELTA    (100)   /* CdS cell illuminance delta for 'Torch Beam Off' state detection */
 #define ILLUMINANCE_DARK  (1000)  /* Value for background noise */
+#define SD_LOG_BUFFER_LEN (78)    /* String buffer length for SD log file */
 // #define HIGH            (1)
 // #define LOW             (0)
 
@@ -97,6 +97,7 @@ void taskOneFunc(){
     static unsigned int  lcdTaskTimerVal = 0;
 
     int symbolPositionOffset = 0;                            /* For OLED display setCursor() */
+    char sdLogBuffer[SD_LOG_BUFFER_LEN];
 
     fullTaskTimerVal = fullTaskTimerStop - fullTaskTimerStart;
     logTaskTimerVal = logTaskTimerStop - logTaskTimerStart;
@@ -266,7 +267,14 @@ void taskOneFunc(){
     
     if(logAsklitt)
     {
-      //logAsklitt.print(logStringFile);
+      sprintf(sdLogBuffer, "%04d/%02d/%02d_%02d:%02d:%02d %4d %6d %d %d %4d %4d %4d %4d \n"
+          , year, mnth, day, hour, minu, seco
+          , sensorValue, activeTimeProgressInd
+          , previousState, currentState, dynamicIlluminanceThr
+          , fullTaskTimerVal, logTaskTimerVal, lcdTaskTimerVal
+          );
+      // logAsklitt.print(logStringFile);
+      logAsklitt.print(sdLogBuffer);
       logAsklitt.close();
     }
     else
@@ -301,7 +309,8 @@ void taskOneFunc(){
 
   // Serial.print(logString);
   // Serial.print(logStringFile);
-  // Serial.print(seco);
+  
+  Serial.print(sdLogBuffer);
 
   previousSensorValue = sensorValue;
   previousDynamicThr = dynamicIlluminanceThr;
@@ -392,8 +401,8 @@ void setup()
   logAsklitt = SD.open(GV_LogFileName, FILE_WRITE);
   if(logAsklitt)
   {
-    logAsklitt.print("--- Starting new log entry ---\n");
-    logAsklitt.print("Time, Light_sensor_value, Active_time_(sec), Previous_state, Current_state, startTimer, stopTimer, dynamicIlluminanceThr, FullTask(ms), SDlogTask(ms), 2xLcdTaskTimerVal(ms)\n");
+    logAsklitt.print(F("--- Starting new log entry ---\n"));
+    logAsklitt.print(F("Time, Light_sensor_value, Active_time_(sec), Previous_state, Current_state, dynamicIlluminanceThr, FullTask(ms), SDlogTask(ms), 2xLcdTaskTimerVal(ms)\n"));
     logAsklitt.close();
   }
   else

--- a/asaklitt.ino
+++ b/asaklitt.ino
@@ -56,12 +56,9 @@ Thread taskOne = Thread();
 
 File logAsklitt;
 
-//U8X8_SSD1306_128X64_NONAME_SW_I2C oled(/* reset=*/ U8X8_PIN_NONE);
-//U8X8_SSD1306_128X64_NONAME_SW_I2C oled(/* clock=*/ SCL, /* data=*/ SDA, /* reset=*/ U8X8_PIN_NONE);   // OLEDs without Reset of the Display
-U8X8_SSD1306_128X32_UNIVISION_SW_I2C oled(/* clock=*/ 5, /* data=*/ 4, /* reset=*/ U8X8_PIN_NONE);   // OLEDs without Reset of the Display
+//   U8X8_SSD1306_128X32_UNIVISION_SW_I2C oled(/* clock=*/ 5, /* data=*/ 4, /* reset=*/ U8X8_PIN_NONE);   // OLEDs without Reset of the Display
 //U8X8_SSD1306_128X64_NONAME_HW_I2C oled(/* reset=*/ U8X8_PIN_NONE);
-//U8G2_SSD1306_128X32_UNIVISION_1_HW_I2C oled(U8G2_R0, /* reset=*/ U8X8_PIN_NONE);
-//U8X8_SSD1306_128X32_UNIVISION_HW_I2C oled(/* reset=*/ U8X8_PIN_NONE, /* clock=*/ SCL, /* data=*/ SDA);   // pin remapping with ESP8266 HW I2C
+U8X8_SSD1306_128X32_UNIVISION_HW_I2C oled(/* reset=*/ U8X8_PIN_NONE, /* clock=*/ SCL, /* data=*/ SDA);   // pin remapping with ESP8266 HW I2C
 
 /** 
  * Returns the number of digits of the integer value


### PR DESCRIPTION
Add OLED display, remove 16x2 LCD.

- i2c 128x32 added with u8x8 library
- LCD disconnected, LiquidCrystal library removed
- Modified the way of choosing the SD log file name, name has the format: "asDDHHMM.txt", where DDHHMM - the day, hour and minute of creation. Main function appends records to the log created at startup.
 
